### PR TITLE
Error referencing Model

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -114,9 +114,9 @@ abstract class Model extends BaseModel
      * Set the mutated attributes at runtime.
      *
      * @param array $moneyAttributes
-     * @return Order
+     * @return \Illuminate\Database\Eloquent\Model
      */
-    public function setMoneyAttributes(array $moneyAttributes): Order
+    public function setMoneyAttributes(array $moneyAttributes): Model
     {
         $this->moneyAttributes = $moneyAttributes;
 


### PR DESCRIPTION
This seems to fix the following issue
Return value of `Appel\MonetaryAttributes\Model::setMoneyAttributes()` must be an instance of `Appel\MonetaryAttributes\Order`, instance of `App\Order` returned